### PR TITLE
Shouldn't the tokenscript files be signed with *private* key

### DIFF
--- a/docs/TokenScript.html
+++ b/docs/TokenScript.html
@@ -44,7 +44,7 @@
                 appends rules, data moduls, transaction security measurements and much more. </li>
         </ul>
         <p dir="ltr" class="p">TokenScript files are <a class="xref" href="Signing.html" title="TokenScript files are signed by the token issuer, usually.">signed by the creator of the
-                token smart contract or a trusted source</a> with a public key. Wallets and dApps
+                token smart contract or a trusted source</a> with a private key. Wallets and dApps
             can import and verify the files and make sure users only get authorized TokenScripts
             from trusted sources.</p>
         <p dir="ltr" class="p">TokenScript is blockchain agnostic. The main focus of our development is based


### PR DESCRIPTION
I believe the TokenScript file should be signed by the creator with their private key, the verified by public key

Please feel free to let me know if that's not how the TokenScript signature works, cheers